### PR TITLE
remove CreateEvent from event processing loop

### DIFF
--- a/gui-agent-windows.wxs
+++ b/gui-agent-windows.wxs
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='windows-1252'?>
-<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:difx="http://schemas.microsoft.com/wix/DifxAppExtension">
 
 <?if $(env.DDK_ARCH) = x64 ?>
     <?define PFILESDIR = ProgramFiles64Folder ?>
@@ -9,43 +9,11 @@
     <?define SYSDIR = SystemFolder ?>
 <?endif ?>
 
-<Module
-Id='GuiAgent'
-Language='1033'
-Codepage='1252'
-Version='$(env.VERSION)'
->
-
-<Package
-Id='{99FAD33F-658E-4F04-966C-52061AC0BC45}'
-Description='Qubes GUI Agent for Windows'
-Manufacturer='Invisible Things Lab'
-InstallScope='perMachine'
-InstallerVersion='200'
-Languages='1033'
-SummaryCodepage='1252'
-InstallPrivileges='elevated'
-/>
-
-<Configuration
-Name='ProductFolder'
-Format='Key'
-Type='Identifier'
-DefaultValue='QubesProgramFilesDir'
-Description='Installation directory'
-DisplayName='Installation directory'
-/>
-
-<Substitution Table='Directory' Column='Directory_Parent' Row='BinDir' Value='[=ProductFolder]'/>
-<Substitution Table='Directory' Column='Directory_Parent' Row='DriversDir' Value='[=ProductFolder]'/>
+<Fragment>
 
 <!--Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" SuppressModularization="yes"/-->
 
-<Directory Id='TARGETDIR' Name='SourceDir'>
-    <Directory Id='$(var.PFILESDIR)'>
-        <Directory Id='ITLProgramFilesDir' Name='Invisible Things Lab'>
-            <Directory Id='QubesProgramFilesDir' Name='Qubes Tools'>
-                <Directory Id='BinDir' Name='bin'>
+                <DirectoryRef Id='BinDir'>
                     <Component Id='GuiAgent' Guid='{69131C28-618B-4662-9AFC-70767E50F05D}'>
                         <File Id='qga.exe' Source='bin\$(env.DDK_ARCH)\qga.exe' KeyPath="yes"/>
                         <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools" Name="Autostart" Type="string" Value='"[BinDir]qga.exe"'/>
@@ -72,41 +40,18 @@ DisplayName='Installation directory'
                         </ServiceInstall>
                         <ServiceControl Id="QgaWatchdogService" Remove="uninstall" Name="QgaWatchdog" Wait="no" />
                     </Component>
-                </Directory>
-                <Directory Id='DriversDir' Name='drivers'>
+                </DirectoryRef>
+                <DirectoryRef Id='DriversDir'>
                     <Directory Id='QvideoDir' Name='qvideo'>
                         <Component Id='qvideo' Guid='{EC90C049-0025-4815-9106-6ABC438470A4}'>
                             <File Id='qvideo.cat' Source='bin\$(env.DDK_ARCH)\qvideo.cat'/>
                             <File Id='qvgdi.dll' Source='bin\$(env.DDK_ARCH)\qvgdi.dll'/>
                             <File Id='qvmini.sys' Source='bin\$(env.DDK_ARCH)\qvmini.sys'/>
                             <File Id='qvideo.inf' Source='bin\$(env.DDK_ARCH)\qvideo.inf'/>
-                            <!-- moved to custom table below -->
-                            <!-- <difx:Driver Sequence='10' Legacy='yes' PlugAndPlayPrompt='no' ForceInstall='yes'/>-->
+                            <difx:Driver Sequence='10' Legacy='yes' PlugAndPlayPrompt='no' ForceInstall='yes'/>
                         </Component>
                     </Directory>
-                </Directory>
-            </Directory>
-        </Directory>
-    </Directory>
-</Directory>
-<!-- cannot use difx:Drive element because it requires difx lib linked with
-this module, which causes conflict with vmm-xen-windows-drivers (which also
-uses DIFx extension). This basically means that only one merge module
-can use DIFx extention (see http://sourceforge.net/p/wix/feature-requests/432/).
-But this also means that final MSI will already have all necesary steps to
-install the drivers. So just append our driver to the MsiDriverPackage
-table, to be also installed. -->
-<!-- Table schema here: http://msdn.microsoft.com/en-us/library/windows/hardware/ff549362%28v=vs.85%29.aspx -->
-<CustomTable Id="MsiDriverPackages">
-    <Column Id="Component" Modularize="Column" Nullable="no" Type="string" Width="255" Description="An identifier that represents a driver package" PrimaryKey="yes"/>
-    <Column Id="Flags" Nullable="no" Type="int" Width="4" Description="DIFxApp configuration flags"/>
-    <Column Id="Sequence" Nullable="yes" Type="int" Width="4" Description="Installation sequence number"/>
-    <Row>
-        <Data Column="Component">qvideo</Data>
-        <Data Column="Flags">15</Data>
-        <Data Column="Sequence">10</Data>
-    </Row>
-</CustomTable>
+                </DirectoryRef>
 
 <Binary Id="CreateDeviceHelper" SourceFile="bin\$(env.DDK_ARCH)\create-device.exe"/>
 <Binary Id="DisableDevHelper" SourceFile="bin\$(env.DDK_ARCH)\disable-device.exe"/>
@@ -171,5 +116,5 @@ http://msdn.microsoft.com/en-us/library/aa368012(v=vs.85).aspx
     </Custom>
 </InstallExecuteSequence>
 
-</Module>
+</Fragment>
 </Wix>

--- a/gui-agent-windows.wxs
+++ b/gui-agent-windows.wxs
@@ -52,6 +52,9 @@
                         </Component>
                     </Directory>
                 </DirectoryRef>
+		
+<SetProperty Id="SignQvideoDriver" Value="&quot;[BinDir]pkihelper.exe&quot; -v -p &quot;[DriversDir]qvideo&quot;" Sequence="execute" Before="SignQvideoDriver"/>
+<CustomAction Id="SignQvideoDriver" Impersonate="no" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore"/>
 
 <Binary Id="CreateDeviceHelper" SourceFile="bin\$(env.DDK_ARCH)\create-device.exe"/>
 <Binary Id="DisableDevHelper" SourceFile="bin\$(env.DDK_ARCH)\disable-device.exe"/>
@@ -101,6 +104,7 @@ $component is future state, ?component is current state
 http://msdn.microsoft.com/en-us/library/aa368012(v=vs.85).aspx
 -->
 <InstallExecuteSequence>
+    <Custom Action="SignQvideoDriver" Before="MsiProcessDrivers"/>
     <Custom Action="RegisterVideoDevice" After="InstallFiles">
         ?qvideo=2 AND $qvideo=3
     </Custom>

--- a/gui-agent-windows.wxs
+++ b/gui-agent-windows.wxs
@@ -15,7 +15,7 @@
 
                 <DirectoryRef Id='BinDir'>
                     <Component Id='GuiAgent' Guid='{69131C28-618B-4662-9AFC-70767E50F05D}'>
-                        <File Id='qga.exe' Source='bin\$(env.DDK_ARCH)\qga.exe' KeyPath="yes"/>
+                        <File Id='qga.exe' Source='$(env.QUBES_BIN)\qga.exe' KeyPath="yes"/>
                         <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools" Name="Autostart" Type="string" Value='"[BinDir]qga.exe"'/>
                         <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools" Name="UseDirtyBits" Type="integer" Value='0'/>
                         <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools\qga" Name="MaxFps" Type="integer" Value='0'/>
@@ -23,7 +23,7 @@
                         <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools\qga" Name="SeamlessMode" Type="integer" Value='0'/>
                     </Component>
                     <Component Id='QgaWatchdog' Guid='{5A490AD9-203D-4634-9ABA-4FB02416D0BC}'>
-                        <File Id='QgaWatchdog.exe' Source='bin\$(env.DDK_ARCH)\QgaWatchdog.exe' KeyPath="yes"/>
+                        <File Id='QgaWatchdog.exe' Source='$(env.QUBES_BIN)\QgaWatchdog.exe' KeyPath="yes"/>
                         <ServiceInstall
                         Id="ServiceInstaller"
                         Type="ownProcess"
@@ -44,10 +44,10 @@
                 <DirectoryRef Id='DriversDir'>
                     <Directory Id='QvideoDir' Name='qvideo'>
                         <Component Id='qvideo' Guid='{EC90C049-0025-4815-9106-6ABC438470A4}'>
-                            <File Id='qvideo.cat' Source='bin\$(env.DDK_ARCH)\qvideo.cat'/>
-                            <File Id='qvgdi.dll' Source='bin\$(env.DDK_ARCH)\qvgdi.dll'/>
-                            <File Id='qvmini.sys' Source='bin\$(env.DDK_ARCH)\qvmini.sys'/>
-                            <File Id='qvideo.inf' Source='bin\$(env.DDK_ARCH)\qvideo.inf'/>
+                            <File Id='qvideo.cat' Source='$(env.QUBES_BIN)\qvideo.cat'/>
+                            <File Id='qvgdi.dll' Source='$(env.QUBES_BIN)\qvgdi.dll'/>
+                            <File Id='qvmini.sys' Source='$(env.QUBES_BIN)\qvmini.sys'/>
+                            <File Id='qvideo.inf' Source='$(env.QUBES_BIN)\qvideo.inf'/>
                             <difx:Driver Sequence='10' Legacy='yes' PlugAndPlayPrompt='no' ForceInstall='yes'/>
                         </Component>
                     </Directory>
@@ -56,8 +56,8 @@
 <SetProperty Id="SignQvideoDriver" Value="&quot;[BinDir]pkihelper.exe&quot; -v -p &quot;[DriversDir]qvideo&quot;" Sequence="execute" Before="SignQvideoDriver"/>
 <CustomAction Id="SignQvideoDriver" Impersonate="no" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore"/>
 
-<Binary Id="CreateDeviceHelper" SourceFile="bin\$(env.DDK_ARCH)\create-device.exe"/>
-<Binary Id="DisableDevHelper" SourceFile="bin\$(env.DDK_ARCH)\disable-device.exe"/>
+<Binary Id="CreateDeviceHelper" SourceFile="$(env.QUBES_BIN)\create-device.exe"/>
+<Binary Id="DisableDevHelper" SourceFile="$(env.QUBES_BIN)\disable-device.exe"/>
 
 <CustomAction
 Id="RegisterVideoDevice"

--- a/gui-agent-windows.wxs
+++ b/gui-agent-windows.wxs
@@ -1,124 +1,155 @@
 <?xml version='1.0' encoding='windows-1252'?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:difx="http://schemas.microsoft.com/wix/DifxAppExtension">
-
-<?if $(env.DDK_ARCH) = x64 ?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:difx="http://schemas.microsoft.com/wix/DifxAppExtension">
+     
+    <?if $(env.DDK_ARCH) = x64 ?>
     <?define PFILESDIR = ProgramFiles64Folder ?>
     <?define SYSDIR = System64Folder ?>
-<?else?>
+    <?else?>
     <?define PFILESDIR = ProgramFilesFolder ?>
     <?define SYSDIR = SystemFolder ?>
-<?endif ?>
-
-<Fragment>
-
-<!--Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" SuppressModularization="yes"/-->
-
-                <DirectoryRef Id='BinDir'>
-                    <Component Id='GuiAgent' Guid='{69131C28-618B-4662-9AFC-70767E50F05D}'>
-                        <File Id='qga.exe' Source='$(env.QUBES_BIN)\qga.exe' KeyPath="yes"/>
-                        <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools" Name="Autostart" Type="string" Value='"[BinDir]qga.exe"'/>
-                        <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools" Name="UseDirtyBits" Type="integer" Value='0'/>
-                        <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools\qga" Name="MaxFps" Type="integer" Value='0'/>
-                        <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools\qga" Name="DisableCursor" Type="integer" Value='1'/>
-                        <RegistryValue Root="HKLM" Key="Software\Invisible Things Lab\Qubes Tools\qga" Name="SeamlessMode" Type="integer" Value='0'/>
-                    </Component>
-                    <Component Id='QgaWatchdog' Guid='{5A490AD9-203D-4634-9ABA-4FB02416D0BC}'>
-                        <File Id='QgaWatchdog.exe' Source='$(env.QUBES_BIN)\QgaWatchdog.exe' KeyPath="yes"/>
-                        <ServiceInstall
-                        Id="ServiceInstaller"
-                        Type="ownProcess"
-                        Vital="yes"
-                        Name="QgaWatchdog"
-                        DisplayName="Qubes Gui Agent Watchdog"
-                        Description="Qubes Gui Agent Watchdog"
-                        Start="auto"
-                        Account="LocalSystem"
-                        ErrorControl="ignore"
-                        Interactive="no"
-                        >
-                            <ServiceDependency Id="QdbDaemon" />
-                        </ServiceInstall>
-                        <ServiceControl Id="QgaWatchdogService" Remove="uninstall" Name="QgaWatchdog" Wait="no" />
-                    </Component>
-                </DirectoryRef>
-                <DirectoryRef Id='DriversDir'>
-                    <Directory Id='QvideoDir' Name='qvideo'>
-                        <Component Id='qvideo' Guid='{EC90C049-0025-4815-9106-6ABC438470A4}'>
-                            <File Id='qvideo.cat' Source='$(env.QUBES_BIN)\qvideo.cat'/>
-                            <File Id='qvgdi.dll' Source='$(env.QUBES_BIN)\qvgdi.dll'/>
-                            <File Id='qvmini.sys' Source='$(env.QUBES_BIN)\qvmini.sys'/>
-                            <File Id='qvideo.inf' Source='$(env.QUBES_BIN)\qvideo.inf'/>
-                            <difx:Driver Sequence='10' Legacy='yes' PlugAndPlayPrompt='no' ForceInstall='yes'/>
-                        </Component>
-                    </Directory>
-                </DirectoryRef>
-		
-<SetProperty Id="SignQvideoDriver" Value="&quot;[BinDir]pkihelper.exe&quot; -v -p &quot;[DriversDir]qvideo&quot;" Sequence="execute" Before="SignQvideoDriver"/>
-<CustomAction Id="SignQvideoDriver" Impersonate="no" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore"/>
-
-<Binary Id="CreateDeviceHelper" SourceFile="$(env.QUBES_BIN)\create-device.exe"/>
-<Binary Id="DisableDevHelper" SourceFile="$(env.QUBES_BIN)\disable-device.exe"/>
-
-<CustomAction
-Id="RegisterVideoDevice"
-Return="check"
-Impersonate="no"
-Execute="deferred"
-BinaryKey="CreateDeviceHelper"
-ExeCommand='"[QvideoDir]qvideo.inf" ITL_QubesVideo'
-/>
-
-<!-- Disable all PCI Display devices. Our device is ROOT device -->
-<CustomAction
-Id="DisableSVGA"
-Return="ignore"
-Impersonate="no"
-Execute="deferred"
-BinaryKey="DisableDevHelper"
-ExeCommand='-d Display'
-/>
-
-<CustomAction
-Id="RollbackDisableSVGA"
-Return="ignore"
-Impersonate="no"
-Execute="rollback"
-BinaryKey="DisableDevHelper"
-ExeCommand='-e Display'
-/>
-
-<CustomAction
-Id="EnableSVGA"
-Return="ignore"
-Impersonate="no"
-Execute="deferred"
-BinaryKey="DisableDevHelper"
-ExeCommand='-e Display'
-/>
-
-<!--
+    <?endif ?>
+    <Fragment>
+        <!--Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" SuppressModularization="yes"/-->
+        <DirectoryRef Id='BinDir'>
+            <Component Id='GuiAgent'
+                       Guid='{69131C28-618B-4662-9AFC-70767E50F05D}'>
+                       
+                <File Id='qga.exe'
+                      Source='$(env.QUBES_BIN)\qga.exe'
+                      KeyPath="yes" />
+                <RegistryValue Root="HKLM"
+                               Key="Software\Invisible Things Lab\Qubes Tools"
+                               Name="Autostart"
+                               Type="string"
+                               Value='"[BinDir]qga.exe"' />
+                <RegistryValue Root="HKLM"
+                               Key="Software\Invisible Things Lab\Qubes Tools"
+                               Name="UseDirtyBits"
+                               Type="integer"
+                               Value='0' />
+                <RegistryValue Root="HKLM"
+                               Key="Software\Invisible Things Lab\Qubes Tools\qga"
+                               Name="MaxFps"
+                               Type="integer"
+                               Value='0' />
+                <RegistryValue Root="HKLM"
+                               Key="Software\Invisible Things Lab\Qubes Tools\qga"
+                               Name="DisableCursor"
+                               Type="integer"
+                               Value='1' />
+                <RegistryValue Root="HKLM"
+                               Key="Software\Invisible Things Lab\Qubes Tools\qga"
+                               Name="SeamlessMode"
+                               Type="integer"
+                               Value='0' />
+            </Component>
+            <Component Id='QgaWatchdog'
+                       Guid='{5A490AD9-203D-4634-9ABA-4FB02416D0BC}'>
+                       
+                <File Id='QgaWatchdog.exe'
+                      Source='$(env.QUBES_BIN)\QgaWatchdog.exe'
+                      KeyPath="yes" />
+                <ServiceInstall Id="ServiceInstaller"
+                                Type="ownProcess"
+                                Vital="yes"
+                                Name="QgaWatchdog"
+                                DisplayName="Qubes Gui Agent Watchdog"
+                                Description="Qubes Gui Agent Watchdog"
+                                Start="auto"
+                                Account="LocalSystem"
+                                ErrorControl="ignore"
+                                Interactive="no">
+                    <ServiceDependency Id="QdbDaemon" />
+                </ServiceInstall>
+                <ServiceControl Id="QgaWatchdogService"
+                                Remove="uninstall"
+                                Name="QgaWatchdog"
+                                Wait="no" />
+            </Component>
+        </DirectoryRef>
+        <DirectoryRef Id='DriversDir'>
+            <Directory Id='QvideoDir'
+                       Name='qvideo'>
+                <Component Id='qvideo'
+                           Guid='{EC90C049-0025-4815-9106-6ABC438470A4}'>
+                           
+                    <File Id='qvideo.cat'
+                          Source='$(env.QUBES_BIN)\qvideo.cat' />
+                    <File Id='qvgdi.dll'
+                          Source='$(env.QUBES_BIN)\qvgdi.dll' />
+                    <File Id='qvmini.sys'
+                          Source='$(env.QUBES_BIN)\qvmini.sys' />
+                    <File Id='qvideo.inf'
+                          Source='$(env.QUBES_BIN)\qvideo.inf' />
+                    <difx:Driver Sequence='10'
+                                 Legacy='yes'
+                                 PlugAndPlayPrompt='no'
+                                 ForceInstall='yes' />
+                </Component>
+            </Directory>
+        </DirectoryRef>
+        <SetProperty Id="SignQvideoDriver"
+                     Value="&quot;[BinDir]pkihelper.exe&quot; -v -p &quot;[DriversDir]qvideo&quot;"
+                     Sequence="execute"
+                     Before="SignQvideoDriver" />
+        <CustomAction Id="SignQvideoDriver"
+                      Impersonate="no"
+                      BinaryKey="WixCA"
+                      DllEntry="WixQuietExec"
+                      Execute="deferred"
+                      Return="ignore" />
+        <Binary Id="CreateDeviceHelper"
+                SourceFile="$(env.QUBES_BIN)\create-device.exe" />
+        <Binary Id="DisableDevHelper"
+                SourceFile="$(env.QUBES_BIN)\disable-device.exe" />
+        <CustomAction Id="RegisterVideoDevice"
+                      Return="check"
+                      Impersonate="no"
+                      Execute="deferred"
+                      BinaryKey="CreateDeviceHelper"
+                      ExeCommand='"[QvideoDir]qvideo.inf" ITL_QubesVideo' />
+        <!-- Disable all PCI Display devices. Our device is ROOT device -->
+        <CustomAction Id="DisableSVGA"
+                      Return="ignore"
+                      Impersonate="no"
+                      Execute="deferred"
+                      BinaryKey="DisableDevHelper"
+                      ExeCommand='-d Display' />
+        <CustomAction Id="RollbackDisableSVGA"
+                      Return="ignore"
+                      Impersonate="no"
+                      Execute="rollback"
+                      BinaryKey="DisableDevHelper"
+                      ExeCommand='-e Display' />
+        <CustomAction Id="EnableSVGA"
+                      Return="ignore"
+                      Impersonate="no"
+                      Execute="deferred"
+                      BinaryKey="DisableDevHelper"
+                      ExeCommand='-e Display' />
+        <!--
 Custom actions are run whether a component is selected for install or not, by default.
 We need to add checks to each action in case this module is not being installed.
 $component is future state, ?component is current state
 2 is 'not installed', 3 is 'installed'
 http://msdn.microsoft.com/en-us/library/aa368012(v=vs.85).aspx
 -->
-<InstallExecuteSequence>
-    <Custom Action="SignQvideoDriver" Before="MsiProcessDrivers"/>
-    <Custom Action="RegisterVideoDevice" After="InstallFiles">
-        ?qvideo=2 AND $qvideo=3
-    </Custom>
-    <Custom Action="RollbackDisableSVGA" Before="DisableSVGA">
-        $qvideo=3
-    </Custom>
-    <Custom Action="DisableSVGA" Before="InstallFinalize">
-        ?qvideo=2 AND $qvideo=3
-    </Custom>
-    <!-- enable it back on uninstall -->
-    <Custom Action="EnableSVGA" Before="InstallFinalize">
-        REMOVE="ALL" AND ?qvideo=3 AND $qvideo=2
-    </Custom>
-</InstallExecuteSequence>
-
-</Fragment>
+        <InstallExecuteSequence>
+            <Custom Action="SignQvideoDriver"
+                    Before="MsiProcessDrivers" />
+            <Custom Action="RegisterVideoDevice"
+                    After="InstallFiles">?qvideo=2 AND
+                    $qvideo=3</Custom>
+            <Custom Action="RollbackDisableSVGA"
+                    Before="DisableSVGA">$qvideo=3</Custom>
+            <Custom Action="DisableSVGA"
+                    Before="InstallFinalize">?qvideo=2 AND
+                    $qvideo=3</Custom>
+            <!-- enable it back on uninstall -->
+            <Custom Action="EnableSVGA"
+                    Before="InstallFinalize">REMOVE="ALL" AND
+                    ?qvideo=3 AND $qvideo=2</Custom>
+        </InstallExecuteSequence>
+    </Fragment>
 </Wix>

--- a/gui-agent/main.c
+++ b/gui-agent/main.c
@@ -795,22 +795,21 @@ static ULONG WINAPI WatchForEvents(void)
     exitLoop = FALSE;
 
     LogInfo("Awaiting for a vchan client, write buffer size: %d", VchanGetWriteBufferSize(g_Vchan));
+    watchedEvents[0] = g_ShutdownEvent;
+    watchedEvents[1] = windowDamageEvent;
+    watchedEvents[2] = fullScreenOnEvent;
+    watchedEvents[3] = fullScreenOffEvent;
+    watchedEvents[4] = g_ResolutionChangeEvent;
+    watchedEvents[5] = libvchan_fd_for_select(g_Vchan);
+    watchedEvents[6] = CreateEvent(NULL, FALSE, FALSE, NULL); // force update event
+    eventCount = 7;
 
     while (TRUE)
     {
-        watchedEvents[0] = g_ShutdownEvent;
-        watchedEvents[1] = windowDamageEvent;
-        watchedEvents[2] = fullScreenOnEvent;
-        watchedEvents[3] = fullScreenOffEvent;
-        watchedEvents[4] = g_ResolutionChangeEvent;
 
         status = ERROR_SUCCESS;
 
         vchanIoInProgress = TRUE;
-
-        watchedEvents[5] = libvchan_fd_for_select(g_Vchan);
-        watchedEvents[6] = CreateEvent(NULL, FALSE, FALSE, NULL); // force update event
-        eventCount = 7;
 
         // Wait for events.
         signaledEvent = WaitForMultipleObjects(eventCount, watchedEvents, FALSE, INFINITE);


### PR DESCRIPTION
While executing WatchForEvents, main loop for an each iteration creates a new auto-reset event. Eventually it ends up with growing kernel waiting time (on WaitForMultipleObjects) and from the user point of view - with high cpu consumption.

QubesOS/qubes-issues#3418
QubesOS/qubes-issues#5065
