### PR TITLE
Connect vchan to GUI domain instead of dom0

### DIFF
--- a/gui-agent/main.c
+++ b/gui-agent/main.c
@@ -1211,7 +1211,7 @@ static ULONG WINAPI WatchForEvents(void)
     HANDLE captureErrorEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 
     // This will not block.
-    if (!VchanInit(6000))
+    if (!VchanInit(g_GuiDomainId, 6000))
     {
         LogError("VchanInit() failed");
         return GetLastError();

--- a/gui-agent/vchan.c
+++ b/gui-agent/vchan.c
@@ -47,7 +47,7 @@ BOOL VchanSendMessage(IN const struct msg_hdr *header, IN int headerSize, IN con
     return TRUE;
 }
 
-BOOL VchanInit(IN int port)
+BOOL VchanInit(IN int domain, IN int port)
 {
     // We give a 5 minute timeout here because xeniface can take some time
     // to load the first time after reboot after pvdrivers installation.
@@ -59,7 +59,7 @@ BOOL VchanInit(IN int port)
     // Investigate if this is a problem with windows vchan implementation or something else.
     // 64k allows for 4 x 1440p screens.
 
-    g_Vchan = VchanInitServer(0, port, 65536, 5 * 60 * 1000);
+    g_Vchan = VchanInitServer(domain, port, 65536, 5 * 60 * 1000);
     if (!g_Vchan)
     {
         LogError("VchanInitServer failed");

--- a/gui-agent/vchan.h
+++ b/gui-agent/vchan.h
@@ -32,7 +32,7 @@
 extern CRITICAL_SECTION g_VchanCriticalSection;
 extern struct libvchan *g_Vchan;
 
-BOOL VchanInit(IN int port);
+BOOL VchanInit(IN int domain, IN int port);
 BOOL VchanSendMessage(IN const struct msg_hdr* header, IN int headerSize, IN const void* data, IN int dataSize, IN const WCHAR* what);
 
 #define VCHAN_SEND_MSG(header, body, what) (\


### PR DESCRIPTION
Window buffers are already shared with correct domain id, but control
connection had still hardcoded dom0

Fixes QubesOS/qubes-issues#10043