### PR TITLE
Local build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-/.artifacts/

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,5 +1,5 @@
 rd /s /q %~dp0\.artifacts
 rd /s /q %~dp0\vs2022\tmp
 rd /s /q %~dp0\vs2022\x64
-del /s /q /f %~dp0\sign.crt
-del /s /q /f %~dp0\include\qwt_version.h
+del /q /a /f %~dp0\sign.crt
+del /q /a /f %~dp0\include\qwt_version.h

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,4 +1,3 @@
-rd /s /q %~dp0\.artifacts
 rd /s /q %~dp0\vs2022\tmp
 rd /s /q %~dp0\vs2022\x64
 del /q /a /f %~dp0\sign.crt


### PR DESCRIPTION
- Fix local clean script
- Don't use local .artifacts dir (remove redundant symlinking/copying for local build)